### PR TITLE
new: set url to public sophon db

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,6 @@ module.exports = {
     exclude: ['simple-websocket']
   },
   env: {
-    DB_CONNECTION_URL: 'ws://localhost:8082'
+    DB_CONNECTION_URL: 'ws://157.230.184.36'
   },
 };


### PR DESCRIPTION
@jacobrosenthal this sets the websocket URL to the public URL of the sophon client that is mining the whole universe.